### PR TITLE
[nightshift] docs-backfill: add missing docstrings to document-skills

### DIFF
--- a/skills_all/claude-scientific-skills/scientific-skills/document-skills/docx/ooxml/scripts/validation/base.py
+++ b/skills_all/claude-scientific-skills/scientific-skills/document-skills/docx/ooxml/scripts/validation/base.py
@@ -921,6 +921,21 @@ class BaseSchemaValidator:
         xml_copy = lxml.etree.fromstring(xml_string)
 
         def process_text_content(text, content_type):
+            """Remove template tags from a text string and record warnings.
+
+            Searches *text* for occurrences of the template pattern.  If any
+            are found, appends warning messages and returns the text with all
+            matches stripped.  Returns the original text unchanged when no
+            tags are present.
+
+            Args:
+                text: The text string to process (may be ``None``).
+                content_type: A label such as ``"text content"`` or
+                    ``"tail content"`` used in warning messages.
+
+            Returns:
+                str or None: The cleaned text, or ``None`` if *text* was falsy.
+            """
             if not text:
                 return text
             matches = list(template_pattern.finditer(text))

--- a/skills_all/claude-scientific-skills/scientific-skills/document-skills/docx/scripts/utilities.py
+++ b/skills_all/claude-scientific-skills/scientific-skills/document-skills/docx/scripts/utilities.py
@@ -356,7 +356,29 @@ def _create_line_tracking_parser():
     """
 
     def set_content_handler(dom_handler):
+        """Replace the parser's content handler with one that tracks element positions.
+
+        Wraps the original content handler so that every time a new element
+        is opened via ``startElementNS`` the current expat line and column
+        numbers are captured and stored on the element as a
+        ``parse_position`` ``(line, column)`` tuple.
+
+        Args:
+            dom_handler: The minidom ``DOMBuilder`` content handler to wrap.
+        """
         def startElementNS(name, tagName, attrs):
+            """Handle a SAX startElementNS event while recording parse position.
+
+            Delegates to the original ``startElementNS`` callback to build
+            the DOM node, then annotates the newly created element with its
+            ``parse_position`` attribute using the expat parser's current
+            line and column numbers.
+
+            Args:
+                name: A ``(namespace, localname)`` tuple for the element.
+                tagName: The qualified tag name string.
+                attrs: The element's attributes mapping.
+            """
             orig_start_cb(name, tagName, attrs)
             cur_elem = dom_handler.elementStack[-1]
             cur_elem.parse_position = (

--- a/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/check_bounding_boxes.py
+++ b/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/check_bounding_boxes.py
@@ -1,10 +1,15 @@
+"""Validate non-overlapping bounding boxes for PDF form field annotations.
+
+Reads a ``fields.json`` file (as described in forms.md) that contains label
+and entry bounding boxes for each form field, checks every pair of boxes on
+the same page for intersections, and verifies that entry boxes are tall
+enough to accommodate their font size.  Outputs human-readable messages
+describing any violations.
+"""
+
 from dataclasses import dataclass
 import json
 import sys
-
-
-# Script to check that the `fields.json` file that Claude creates when analyzing PDFs
-# does not have overlapping bounding boxes. See forms.md.
 
 
 @dataclass
@@ -14,13 +19,38 @@ class RectAndField:
     field: dict
 
 
-# Returns a list of messages that are printed to stdout for Claude to read.
 def get_bounding_box_messages(fields_json_stream) -> list[str]:
+    """Read a fields JSON stream and return a list of validation messages.
+
+    Checks all label and entry bounding boxes for pairwise intersections on
+    each page, and ensures each entry box is tall enough for its font size.
+    Returns a list of strings starting with a count of fields read, followed
+    by ``SUCCESS`` or ``FAILURE`` lines for each check.
+
+    Args:
+        fields_json_stream: A file-like object containing the fields JSON.
+
+    Returns:
+        list[str]: Validation messages suitable for printing to stdout.
+    """
     messages = []
     fields = json.load(fields_json_stream)
     messages.append(f"Read {len(fields['form_fields'])} fields")
 
     def rects_intersect(r1, r2):
+        """Return True if axis-aligned rectangles r1 and r2 overlap.
+
+        Each rectangle is a four-element list ``[x1, y1, x2, y2]`` where
+        ``(x1, y1)`` is the lower-left corner and ``(x2, y2)`` is the
+        upper-right corner.
+
+        Args:
+            r1: First rectangle as ``[x1, y1, x2, y2]``.
+            r2: Second rectangle as ``[x1, y1, x2, y2]``.
+
+        Returns:
+            bool: ``True`` if the rectangles share any area, ``False`` otherwise.
+        """
         disjoint_horizontal = r1[0] >= r2[2] or r1[2] <= r2[0]
         disjoint_vertical = r1[1] >= r2[3] or r1[3] <= r2[1]
         return not (disjoint_horizontal or disjoint_vertical)

--- a/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/check_fillable_fields.py
+++ b/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/check_fillable_fields.py
@@ -1,3 +1,11 @@
+"""Detect whether a PDF contains fillable (AcroForm) form fields.
+
+A lightweight script that opens a PDF and reports whether pypdf's
+``get_fields`` returns any interactive form fields.  Used by downstream
+tooling to decide whether to use native field filling or text annotations.
+See forms.md.
+"""
+
 import sys
 from pypdf import PdfReader
 

--- a/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/convert_pdf_to_images.py
+++ b/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/convert_pdf_to_images.py
@@ -1,13 +1,29 @@
+"""Convert each page of a PDF to a PNG image.
+
+Uses ``pdf2image`` to rasterise PDF pages at 200 DPI, optionally scales
+images so that neither dimension exceeds a configurable maximum, and saves
+each page as a numbered PNG file.
+"""
+
 import os
 import sys
 
 from pdf2image import convert_from_path
 
 
-# Converts each page of a PDF to a PNG image.
-
-
 def convert(pdf_path, output_dir, max_dim=1000):
+    """Convert every page of a PDF to a scaled PNG image.
+
+    Renders pages at 200 DPI, resizes any image whose width or height
+    exceeds ``max_dim`` while preserving aspect ratio, and writes the
+    results to ``output_dir`` as ``page_1.png``, ``page_2.png``, etc.
+
+    Args:
+        pdf_path: Path to the input PDF file.
+        output_dir: Directory where PNG images will be saved.
+        max_dim: Maximum allowed width or height in pixels; images
+            exceeding this are proportionally scaled down.
+    """
     images = convert_from_path(pdf_path, dpi=200)
 
     for i, image in enumerate(images):

--- a/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/create_validation_image.py
+++ b/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/create_validation_image.py
@@ -1,14 +1,30 @@
+"""Create visual validation images by drawing bounding-box rectangles on PDF page images.
+
+Overlays red rectangles on entry bounding boxes and blue rectangles on label
+bounding boxes so that downstream tools can visually verify the positions
+Claude predicted for text annotations.  See forms.md for the expected JSON
+format.
+"""
+
 import json
 import sys
 
 from PIL import Image, ImageDraw
 
 
-# Creates "validation" images with rectangles for the bounding box information that
-# Claude creates when determining where to add text annotations in PDFs. See forms.md.
-
-
 def create_validation_image(page_number, fields_json_path, input_path, output_path):
+    """Draw bounding-box rectangles onto a page image for visual verification.
+
+    Reads the fields JSON, opens the source image (a PNG rendering of the
+    PDF page), and draws a red rectangle over each entry bounding box and a
+    blue rectangle over each label bounding box for the specified page.
+
+    Args:
+        page_number: The 1-based page number whose fields should be drawn.
+        fields_json_path: Path to the ``fields.json`` file.
+        input_path: Path to the source PNG image for the page.
+        output_path: Destination path for the annotated PNG image.
+    """
     # Input file should be in the `fields.json` format described in forms.md.
     with open(fields_json_path, 'r') as f:
         data = json.load(f)

--- a/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/extract_form_field_info.py
+++ b/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/extract_form_field_info.py
@@ -1,15 +1,34 @@
+"""Extract metadata from fillable PDF form fields and write to JSON.
+
+Reads a PDF with fillable form fields, collects each field's identifier,
+type (text, checkbox, radio group, or choice), page location, bounding
+rectangle, and available option values, then serialises the result as JSON
+that downstream tools use to fill the fields.  See forms.md for the output
+format.
+"""
+
 import json
 import sys
 
 from pypdf import PdfReader
 
 
-# Extracts data for the fillable form fields in a PDF and outputs JSON that
-# Claude uses to fill the fields. See forms.md.
-
-
 # This matches the format used by PdfReader `get_fields` and `update_page_form_field_values` methods.
 def get_full_annotation_field_id(annotation):
+    """Walk up the annotation's /Parent chain and return the dotted field ID.
+
+    PDF form fields may be nested inside parent nodes that carry partial
+    names.  This function concatenates the names from the innermost child
+    to the outermost parent, joined by ``.``, matching the convention used
+    by ``PdfReader.get_fields``.
+
+    Args:
+        annotation: A pypdf annotation dictionary object.
+
+    Returns:
+        str or None: The fully-qualified dotted field name, or ``None`` if
+        the annotation has no ``/T`` entries in its hierarchy.
+    """
     components = []
     while annotation:
         field_name = annotation.get('/T')
@@ -20,6 +39,21 @@ def get_full_annotation_field_id(annotation):
 
 
 def make_field_dict(field, field_id):
+    """Build a metadata dictionary for a single form field.
+
+    Determines the field type (text, checkbox, choice, or unknown) from
+    the ``/FT`` entry and populates type-specific metadata such as checked
+    and unchecked values for checkboxes, or available options for choice
+    fields.
+
+    Args:
+        field: A pypdf field dictionary.
+        field_id: The fully-qualified field identifier string.
+
+    Returns:
+        dict: A dictionary with at least ``field_id`` and ``type`` keys,
+        plus additional keys depending on the field type.
+    """
     field_dict = {"field_id": field_id}
     ft = field.get('/FT')
     if ft == "/Tx":
@@ -50,16 +84,21 @@ def make_field_dict(field, field_id):
     return field_dict
 
 
-# Returns a list of fillable PDF fields:
-# [
-#   {
-#     "field_id": "name",
-#     "page": 1,
-#     "type": ("text", "checkbox", "radio_group", or "choice")
-#     // Per-type additional fields described in forms.md
-#   },
-# ]
 def get_field_info(reader: PdfReader):
+    """Extract fillable form field metadata from a PDF.
+
+    Scans the PDF for interactive form fields, resolves their types, page
+    locations, and bounding rectangles, and returns a sorted list of field
+    descriptor dictionaries.
+
+    Args:
+        reader: An initialised ``PdfReader`` instance.
+
+    Returns:
+        list[dict]: A list of field dictionaries sorted by page number,
+        then Y position (top-to-bottom in PDF coordinates), then X position.
+        Each dictionary contains at least ``field_id``, ``type``, and ``page``.
+    """
     fields = reader.get_fields()
 
     field_info_by_id = {}
@@ -124,6 +163,19 @@ def get_field_info(reader: PdfReader):
 
     # Sort by page number, then Y position (flipped in PDF coordinate system), then X.
     def sort_key(f):
+        """Return a sort key tuple ``(page, [adjusted_y, x])`` for a field dict.
+
+        Handles both plain fields (with a ``rect`` key) and radio groups
+        (with nested ``radio_options``).  The Y coordinate is negated so
+        that fields nearer the top of the page sort first in the PDF
+        coordinate system where Y increases upward.
+
+        Args:
+            f: A field descriptor dictionary.
+
+        Returns:
+            list: ``[page, [negated_y, x]]`` suitable for use as a sort key.
+        """
         if "radio_options" in f:
             rect = f["radio_options"][0]["rect"] or [0, 0, 0, 0]
         else:
@@ -138,6 +190,12 @@ def get_field_info(reader: PdfReader):
 
 
 def write_field_info(pdf_path: str, json_output_path: str):
+    """Read a PDF, extract form field metadata, and write it to a JSON file.
+
+    Args:
+        pdf_path: Path to the source PDF file.
+        json_output_path: Destination path for the JSON output.
+    """
     reader = PdfReader(pdf_path)
     field_info = get_field_info(reader)
     with open(json_output_path, "w") as f:

--- a/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/fill_fillable_fields.py
+++ b/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/fill_fillable_fields.py
@@ -1,3 +1,11 @@
+"""Fill fillable form fields in a PDF document.
+
+Reads a JSON file describing field values (as produced by
+``extract_form_field_info.py``), validates each value against the field's
+expected type and options, and writes the filled PDF to a new file.
+See forms.md for the input JSON format.
+"""
+
 import json
 import sys
 
@@ -6,10 +14,18 @@ from pypdf import PdfReader, PdfWriter
 from extract_form_field_info import get_field_info
 
 
-# Fills fillable form fields in a PDF. See forms.md.
-
-
 def fill_pdf_fields(input_pdf_path: str, fields_json_path: str, output_pdf_path: str):
+    """Fill form fields in a PDF using values from a JSON file.
+
+    Validates that every field ID referenced in the JSON exists in the PDF
+    and that each value is appropriate for the field type.  Exits with
+    status 1 on the first validation error.
+
+    Args:
+        input_pdf_path: Path to the source PDF containing form fields.
+        fields_json_path: Path to a JSON file with field values to write.
+        output_pdf_path: Destination path for the filled PDF.
+    """
     with open(fields_json_path) as f:
         fields = json.load(f)
     # Group by page number.
@@ -57,6 +73,19 @@ def fill_pdf_fields(input_pdf_path: str, fields_json_path: str, output_pdf_path:
 
 
 def validation_error_for_field_value(field_info, field_value):
+    """Check whether a value is valid for the given field and return an error message if not.
+
+    For checkbox fields the value must match the checked or unchecked value.
+    For radio groups the value must be one of the defined option values.
+    For choice (list/combo) fields the value must appear in the available options.
+
+    Args:
+        field_info: A field descriptor dictionary (from ``get_field_info``).
+        field_value: The proposed value to validate.
+
+    Returns:
+        str or None: An error message string if the value is invalid, otherwise ``None``.
+    """
     field_type = field_info["type"]
     field_id = field_info["field_id"]
     if field_type == "checkbox":
@@ -75,25 +104,45 @@ def validation_error_for_field_value(field_info, field_value):
     return None
 
 
-# pypdf (at least version 5.7.0) has a bug when setting the value for a selection list field.
-# In _writer.py around line 966:
-#
-# if field.get(FA.FT, "/Tx") == "/Ch" and field_flags & FA.FfBits.Combo == 0:
-#     txt = "\n".join(annotation.get_inherited(FA.Opt, []))
-#
-# The problem is that for selection lists, `get_inherited` returns a list of two-element lists like
-# [["value1", "Text 1"], ["value2", "Text 2"], ...]
-# This causes `join` to throw a TypeError because it expects an iterable of strings.
-# The horrible workaround is to patch `get_inherited` to return a list of the value strings.
-# We call the original method and adjust the return value only if the argument to `get_inherited`
-# is `FA.Opt` and if the return value is a list of two-element lists.
 def monkeypatch_pydpf_method():
+    """Patch a pypdf bug in ``DictionaryObject.get_inherited`` for selection-list fields.
+
+    pypdf (at least version 5.7.0) has a bug when setting the value for a
+    selection-list field. In ``_writer.py`` around line 966:
+
+    .. code-block:: python
+
+        if field.get(FA.FT, "/Tx") == "/Ch" and field_flags & FA.FfBits.Combo == 0:
+            txt = "\\n".join(annotation.get_inherited(FA.Opt, []))
+
+    The problem is that for selection lists, ``get_inherited`` returns a list
+    of two-element lists like ``[["value1", "Text 1"], ...]`` which causes
+    ``join`` to raise a ``TypeError``.  This function monkey-patches
+    ``DictionaryObject.get_inherited`` so that, when the key is ``Opt`` and
+    the result is a list of two-element lists, it flattens to just the first
+    element of each pair.
+    """
     from pypdf.generic import DictionaryObject
     from pypdf.constants import FieldDictionaryAttributes
 
     original_get_inherited = DictionaryObject.get_inherited
 
     def patched_get_inherited(self, key: str, default = None):
+        """Replacement for ``DictionaryObject.get_inherited`` that flattens /Opt values.
+
+        Calls the original method and, when the requested key is ``Opt`` and
+        the result is a list of two-element lists (value/text pairs), returns
+        only the value strings.
+
+        Args:
+            self: The ``DictionaryObject`` instance (bound implicitly).
+            key: The dictionary key to look up.
+            default: Value to return if the key is not found.
+
+        Returns:
+            The original result, or a flattened list of value strings for
+            ``Opt`` entries.
+        """
         result = original_get_inherited(self, key, default)
         if key == FieldDictionaryAttributes.Opt:
             if isinstance(result, list) and all(isinstance(v, list) and len(v) == 2 for v in result):

--- a/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/fill_pdf_form_with_annotations.py
+++ b/skills_all/claude-scientific-skills/scientific-skills/document-skills/pdf/scripts/fill_pdf_form_with_annotations.py
@@ -1,3 +1,12 @@
+"""Fill a PDF by adding FreeText annotations defined in a fields JSON file.
+
+When a PDF does not have native fillable form fields, this script adds text
+annotations at the positions described in ``fields.json`` (see forms.md).
+It transforms image-space bounding-box coordinates into PDF coordinates,
+creates a ``FreeText`` annotation for each entry, and writes the result to
+a new PDF file.
+"""
+
 import json
 import sys
 

--- a/skills_all/claude-scientific-skills/scientific-skills/document-skills/pptx/ooxml/scripts/validation/base.py
+++ b/skills_all/claude-scientific-skills/scientific-skills/document-skills/pptx/ooxml/scripts/validation/base.py
@@ -921,6 +921,21 @@ class BaseSchemaValidator:
         xml_copy = lxml.etree.fromstring(xml_string)
 
         def process_text_content(text, content_type):
+            """Remove template tags from a text string and record warnings.
+
+            Searches *text* for occurrences of the template pattern.  If any
+            are found, appends warning messages and returns the text with all
+            matches stripped.  Returns the original text unchanged when no
+            tags are present.
+
+            Args:
+                text: The text string to process (may be ``None``).
+                content_type: A label such as ``"text content"`` or
+                    ``"tail content"`` used in warning messages.
+
+            Returns:
+                str or None: The cleaned text, or ``None`` if *text* was falsy.
+            """
             if not text:
                 return text
             matches = list(template_pattern.finditer(text))


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** Documentation Backfiller (docs-backfill)
**Category:** PR
**Changes:** Added 7 module-level docstrings and 16 function docstrings across 10 files in the document-skills module. No logic changes. +277 lines across 10 files.

Merge if useful, close if not.